### PR TITLE
Edited lib/shrinker.rb via GitHub

### DIFF
--- a/lib/shrinker.rb
+++ b/lib/shrinker.rb
@@ -1,10 +1,15 @@
 class Shrinker
   require "open-uri"
   require "net/http"
-  require "erb"
-  include ERB::Util
   
   IS_GD_URL = "http://is.gd/api.php?longurl="
+
+  # From erb.rb
+  def self.url_encode(s)
+    s.to_s.dup.force_encoding("ASCII-8BIT").gsub(/[^a-zA-Z0-9_\-.]/n) {
+      sprintf("%%%02X", $&.unpack("C")[0])
+    }
+  end
 
   def self.shrink(url)
     unless url.match(/^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?$/ix)

--- a/lib/shrinker.rb
+++ b/lib/shrinker.rb
@@ -1,6 +1,8 @@
 class Shrinker
   require "open-uri"
   require "net/http"
+  require "erb"
+  include ERB::Util
   
   IS_GD_URL = "http://is.gd/api.php?longurl="
 
@@ -9,7 +11,7 @@ class Shrinker
       raise ShrinkError.new("Supplied URL was not formatted as a URL.  Please format it as http://www.domain.com/")
     end
 
-    encoded_url = URI.encode(IS_GD_URL + url)
+    encoded_url = IS_GD_URL + url_encode(url)
 
     begin
       shrunken_url = OpenURI.open_uri(encoded_url, 'r') { |file| file.read }

--- a/lib/shrinker.rb
+++ b/lib/shrinker.rb
@@ -6,9 +6,7 @@ class Shrinker
 
   # From erb.rb
   def self.url_encode(s)
-    s.to_s.dup.force_encoding("ASCII-8BIT").gsub(/[^a-zA-Z0-9_\-.]/n) {
-      sprintf("%%%02X", $&.unpack("C")[0])
-    }
+    s.to_s.gsub(/[^a-zA-Z0-9_\-.]/n){ sprintf("%%%02X", $&.unpack("C")[0]) }
   end
 
   def self.shrink(url)


### PR DESCRIPTION
Fix url encoding - there may be a better way (there probably is) but the various CGI module encoders just don't work. The url_encode method from the ERB::Util class works like a champ (see the bug report)
